### PR TITLE
Sql like explanation for belongs_to has_many

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,28 +142,6 @@ aesop_rock.songs.count
 
 So just by adding our artist object to our songs, our artists can now find all of their songs!
 
-As we can see, it can become somewhat tedious to keep having to call `Song.new` and pass in both our new song's name as a string and our new songs artist as an artist object. It would be really nice if our artist could just create the song. Maybe something like an `#add_song` method?
-
-```ruby
-class Artist
-  attr_accessor :name
-
-  def initialize(name)
-    @name = name
-  end
-
-  def add_song(song_name, genere_name)
-    Song.new(song_name, genere_name, self)
-  end
-
-  def songs
-    Song.all.select { | song | song.artist == self}
-  end
-end
-```
-
-Ahh, much better! Now our artists can create their own songs with just a string for a name and a genre.
-
 ### Relating Objects with "belongs to" and "has many"
 
 So now if a song has an artist object stored in their `@artist` instance variable, it's really easy for us to follow this association from both directions:
@@ -197,6 +175,30 @@ end
 ## Extending the Association and Cleaning up our Code
 
 The code we have so far is pretty good. The best thing about it though, is that it accommodates future change. We've built solid associations between our `Artist` and `Song` class via our has many/belongs to code. With this foundation we can make our code even better in the following ways:
+
+### The `#add_song_by_name` Method
+
+As we can see, it can become somewhat tedious to keep having to call `Song.new` and pass in both our new song's name as a string and our new songs artist as an artist object. It would be really nice if our artist could just create the song. Maybe something like an `#add_song_by_name` method?
+
+```ruby
+class Artist
+  attr_accessor :name
+
+  def initialize(name)
+    @name = name
+  end
+
+  def add_song_by_name(song_name, genere_name)
+    Song.new(song_name, genere_name, self)
+  end
+
+  def songs
+    Song.all.select { | song | song.artist == self}
+  end
+end
+```
+
+Ahh, much better! Now our artists can create their own songs with just a string for a name and a genre.
 
 ### The `#artist_name` Method
 

--- a/README.md
+++ b/README.md
@@ -232,7 +232,3 @@ Much better. Notice that we used the `self` keyword inside the `#artist_name` me
 These are only a few of the ways in which you can extend, or build on, the foundational has many and belongs to associations.
 
 <p data-visibility='hidden'>View <a href='https://learn.co/lessons/ruby-objects-has-many-readme' title='Ruby Objects: The "Has Many" Relationship'>Ruby Objects: The "Has Many" Relationship</a> on Learn.co and start learning to code for free.</p>
-
-<p data-visibility='hidden'>View <a href='https://learn.co/lessons/ruby-objects-has-many-readme'>Has Many Object</a> on Learn.co and start learning to code for free.</p>
-
-<p class='util--hide'>View <a href='https://learn.co/lessons/ruby-objects-has-many-readme'>Has Many Object</a> on Learn.co and start learning to code for free.</p>


### PR DESCRIPTION
Changes readme to explain the belongs_to has_many in a way that better maps to SQL. Artist will no longer have `@songs` array, but rather search `Song.all` for songs where they are the artist. 

@pletcher and @JeffKatzy this is my first pass at updating the readme. I'm going to continue by working on the rest of this section, but I was just wondering if I might get a first pass glance over from you to make sure we're on the same page. 

cc: @AnnJohn @PeterBell 

Note: This is not to be merged in until entire section is complete!
